### PR TITLE
Add flag to display maxas version info.

### DIFF
--- a/bin/maxas.pl
+++ b/bin/maxas.pl
@@ -189,6 +189,11 @@ elsif ($mode =~ /^\-?\-p/i)
     print $fh MaxAs::MaxAs::Preprocess($file, $debug);
     close $fh;
 }
+# get version information
+elsif ($mode =~ /^\-?\-v/i)
+{
+    print "$MaxAs::MaxAs::VERSION\n";
+}
 else
 {
     print "$mode\n";
@@ -228,8 +233,11 @@ Usage:
   Optionally you can skip register reuse flag auto insertion.  This allows you to observe
   performance without any reuse or you can use it to set the flags manually in your sass.
 
-
     maxas.pl --insert|-i [--noreuse|-n] <asm_file> <cubin_file> [new_cubin_file]
+
+  Display version information and exit:
+
+    maxas.pl --version|-v
 
 EOF
     exit(1);

--- a/lib/MaxAs/MaxAs.pm
+++ b/lib/MaxAs/MaxAs.pm
@@ -7,7 +7,7 @@ use Data::Dumper;
 use MaxAs::MaxAsGrammar;
 use Carp;
 
-our $VERSION = '1.01';
+our $VERSION = '1.02';
 
 # these ops need to be converted from absolute addresses to relative in the sass output by cuobjdump
 my %relOffset  = map { $_ => 1 } qw(BRA SSY CAL PBK PCNT);


### PR DESCRIPTION
Small patch that makes it easy to report what version of maxas is installed.  VERSION should be incremented each time the module changes.
