### PR TITLE
Purge superfluous (?) braces in cubobjdump output

### DIFF
--- a/lib/MaxAs/MaxAs.pm
+++ b/lib/MaxAs/MaxAs.pm
@@ -686,6 +686,9 @@ sub Extract
         {
             $line = <$in>;
 
+            # skip superfluous (?) braces in cuobjdump output
+            $line =~ s/{//g;
+            $line =~ s/}//g;
             my $inst = processSassLine($line) or next CTRL;
 
             # Convert branch/jump/call addresses to labels


### PR DESCRIPTION
Purge superfluous (?) braces in cubobjdump output, see https://github.com/NervanaSystems/maxas/issues/10#issuecomment-220947043

Not sure if they are strictly superfluous?  But in any case in the example used, the braces caused maxas.pl to not recognize the instructions at all.  With this patch, the instructions are at least recognized, and printed to the .sass output
